### PR TITLE
Allow parens inside if((foo) AND (bar)), also allow multi-line strings

### DIFF
--- a/cmakelists_parsing/parsing.py
+++ b/cmakelists_parsing/parsing.py
@@ -130,13 +130,20 @@ def attach_comment_to_command(lnums_command, lnums_comment):
 
 def parse_command(start_line_num, command_name, toks):
     cmd = Command(name=command_name, body=[], comment=None)
+    open_paren_count = 0
     expect('left paren', toks)
     for line_num, (typ, tok_contents) in toks:
         if typ == 'right paren':
-            line_nums = range(start_line_num, line_num + 1)
-            return line_nums, cmd
+            if open_paren_count == 0:
+                line_nums = range(start_line_num, line_num + 1)
+                return line_nums, cmd
+            else:
+                open_paren_count -= 1
+                cmd.body.append(Arg(tok_contents, []))
         elif typ == 'left paren':
-            raise ValueError('Unexpected left paren at line %s' % line_num)
+            open_paren_count += 1
+            cmd.body.append(Arg(tok_contents, []))
+            #raise ValueError('Unexpected left paren at line %s' % line_num)
         elif typ in ('word', 'string'):
             cmd.body.append(Arg(tok_contents, []))
         elif typ == 'comment':
@@ -157,28 +164,28 @@ def expect(expected_type, toks):
         raise CMakeParseError(msg)
 
 # http://stackoverflow.com/questions/691148/pythonic-way-to-implement-a-tokenizer
-# TODO: Handle multiline strings.
+string_regex = re.compile(r'".*[^\\]?"', re.DOTALL)
 scanner = re.Scanner([
-    (r'#.*',                lambda scanner, token: ("comment", token)),
-    (r'"[^"]*"',            lambda scanner, token: ("string", token)),
+    (r'#[^\n]*',            lambda scanner, token: ("comment", token)),
+    (r'".*[^\\]?"',         lambda scanner, token: ("string", token)),
     (r"\(",                 lambda scanner, token: ("left paren", token)),
     (r"\)",                 lambda scanner, token: ("right paren", token)),
     (r'[^ \t\r\n()#"]+',    lambda scanner, token: ("word", token)),
     (r'\n',                 lambda scanner, token: ("newline", token)),
     (r"\s+",                None), # skip other whitespace
-])
+], re.DOTALL)
 
 def tokenize(s):
     """
     Yields pairs of the form (line_num, (token_type, token_contents))
     given a string containing the contents of a CMakeLists file.
     """
+
     toks, remainder = scanner.scan(s)
     if remainder != '':
-        msg = 'Unrecognized tokens at line %s: %s' % (line_num, remainder)
+        msg = 'Unrecognized tokens at line %s: %s' % (-1, remainder)
         raise ValueError(msg)
     line_num = 1
     for tok_type, tok_contents in toks:
         yield line_num, (tok_type, tok_contents.strip())
         line_num += tok_contents.count('\n')
-


### PR DESCRIPTION
1. Fix parse failure for parentheses inside if-statements, e.g. 

``` .cmake
    if((FOO OR BAR) AND (FOO OR BAZ))
```
1. Fix local variable line_number used before defined in tokenize()
2. Rudimentary support for multiline string (it is parsed as a string Arg)
3. Fix parse error for escaped quote (i.e. " \" ") inside cmake string
